### PR TITLE
SUSE-check in spec filed

### DIFF
--- a/amdgpu-pro-opencl.spec
+++ b/amdgpu-pro-opencl.spec
@@ -37,9 +37,13 @@ URL:            https://www.amd.com/en/support/kb/release-notes/rn-amdgpu-unifie
 Source0:        https://drivers.amd.com/drivers/linux/amdgpu-pro-%{major}-%{minor}-%{distro}.tar.xz
 
 ExclusiveArch:  x86_64
-#BuildRequires:  
+#BuildRequires:
+%if 0%{?suse_version}
+Requires:       libdrm2
+%else
 Requires:       ocl-icd
-Requires:	libdrm
+Requires:       libdrm
+%endif
 
 %description
 OpenCL userspace driver as provided in the amdgpu-pro driver stack. This package
@@ -143,6 +147,12 @@ ln -s libdro.so.2.4.0        %{buildroot}%{_libdir}/amdgpu-pro-opencl/libdro.so.
 
 
 %changelog
+* Sat May 29 2021 Castor Sky - SUSE stuff
+- Added SUSE libdrm-related check
+
+* Sat May 8 2021 GloriousEggroll - 21.10-1247438
+- Update to 21.10
+
 * Sat Feb 20 2021 optimize-fast - 20.45.1188099-1
 - Update to 20.45
 

--- a/install.sh
+++ b/install.sh
@@ -9,5 +9,5 @@ fi
 cd ~/rpmbuild/SPECS
 git clone https://github.com/GloriousEggroll/rpm-amdgpu-pro-opencl amdgpu-pro-opencl
 cd amdgpu-pro-opencl
-rpmbuild -ba amdgpu-pro-opencl.spec
+rpmbuild -bb amdgpu-pro-opencl.spec
 sudo dnf -y --nogpgcheck install ~/rpmbuild/RPMS/x86_64/amdgpu-pro-opencl-*.x86_64.rpm


### PR DESCRIPTION
SUSE have no oci-icd and libdrm have name "libdrm2"
Tested on openSUSE Leap 15.3 and Tumbleweed